### PR TITLE
Turkish Language Update

### DIFF
--- a/src/main/resources/assets/toomanyorigins/lang/tr_tr.json
+++ b/src/main/resources/assets/toomanyorigins/lang/tr_tr.json
@@ -29,7 +29,7 @@
     "death.attack.overheat.player.item": "%1$s, %3$s kullanan %2$s'den kaçmaya çalışırken içini fitilledi.",
   
     "power.toomanyorigins.hover.name": "Süzül",
-    "power.toomanyorigins.hover.description": "Düşeceğin zaman havada asılı kalabilirsin, bu şüreç seni yorar ve uzak mesafe silah kullanamamanı sağlar.",
+    "power.toomanyorigins.hover.description": "Düşeceğin zaman havada asılı kalabilirsin, bu şüreç seni yorar ve uzun menzilli silah kullanamamanı sağlar.",
     "power.toomanyorigins.pollination.name": "Tozlaşma",
     "power.toomanyorigins.pollination.description": "Eğilmiyorken kemik tozu kullanmak yanlardaki 4 bloğa da etki eder.",
     "power.toomanyorigins.calming_aura.name": "Sakin Aura",

--- a/src/main/resources/assets/toomanyorigins/lang/tr_tr.json
+++ b/src/main/resources/assets/toomanyorigins/lang/tr_tr.json
@@ -29,13 +29,13 @@
     "death.attack.overheat.player.item": "%1$s, %3$s kullanan %2$s'den kaçmaya çalışırken içini fitilledi.",
   
     "power.toomanyorigins.hover.name": "Süzül",
-    "power.toomanyorigins.hover.description": "Düşeceğin zaman havada asılı kalabilirsin, bu şüreçte biraz acıkırsın.",
+    "power.toomanyorigins.hover.description": "Düşeceğin zaman havada asılı kalabilirsin, bu şüreç seni yorar ve uzak mesafe silah kullanamamanı sağlar.",
     "power.toomanyorigins.pollination.name": "Tozlaşma",
     "power.toomanyorigins.pollination.description": "Eğilmiyorken kemik tozu kullanmak yanlardaki 4 bloğa da etki eder.",
     "power.toomanyorigins.calming_aura.name": "Sakin Aura",
     "power.toomanyorigins.calming_aura.description": "Çiftleştirdiğin saldırgan olmayan hayvanların tekrar çiftleşebilmesi için beklemene gerek yok.",
     "power.toomanyorigins.stinging_pains.name": "Batırmanın Acısı",
-    "power.toomanyorigins.stinging_pains.description": "Düşman canlıları doğrudan öldürdüğünde acıkırsın.",
+    "power.toomanyorigins.stinging_pains.description": "Düşman canlılara doğrudan hasar vermek seni yorar.",
     "power.toomanyorigins.unity.name": "Birlik",
     "power.toomanyorigins.unity.description": "Maksimum canın, açlık seviyene bağlı.",
 
@@ -48,8 +48,7 @@
     "power.toomanyorigins.spirit_strider.name": "Ruh Gezer",
     "power.toomanyorigins.spirit_strider.description": "Her zaman bir seviye ekstra ruh hızın var.",
     "power.toomanyorigins.deathly_digestion.name": "Ölümcül Sindiriş",
-    "power.toomanyorigins.deathly_digestion.description": "Yemek eşyaları senin için daha az doyurucu.",
-    "toomanyorigins.gui.badge.overworld_exhaustion": "Nether'da değilken çok daha çabuk acıkırsın.",
+    "power.toomanyorigins.deathly_digestion.description": "Nether'da değil isen daha çabuk yorulursun ve yemeklerden tamamen yararlanamazsın.",
 
     "toomanyorigins.midnightconfig.title": "TooManyOrigins Ayarları",
     "toomanyorigins.midnightconfig.dragonFireballMixinOptions": "§nEnder Ejderhası Ateş Topu Karışım Ayarları§r",
@@ -58,6 +57,7 @@
     "toomanyorigins.gui.version_mismatch": "Bu server başka bir TooManyOrigins versiyonu (v%1$s) çalıştırıyor ve sende mevcut olan versiyonla uyumlu değil (v%2$s).",
     "toomanyorigins.content.disabled": "Devre Dışı",
     "toomanyorigins.content.disabled_message": "Eski TooManyOrigins modülü '%1$s' devre dışı. 'data/toomanyorigins/legacy_content.json' dosya konumunda bulunan bir datapack ile etkinleştiriniz.",
+    "dataPack.legacytoomanyorigins.name": "Eski TooManyOrigins",
     "dataPack.legacytoomanyorigins.description": "Bütün rework öncesi TooManyOrigins içeriklerini geri getirir.",
 
     "origin.legacytoomanyorigins.dragonborn.description": "Yarı İnsan, Yarı Ejderha. Vahşi nefesleri ve yapıları End'in diğer sakinlerinin onlara baş eğmelerini sağlar.",

--- a/src/main/resources/assets/toomanyorigins/lang/tr_tr.json
+++ b/src/main/resources/assets/toomanyorigins/lang/tr_tr.json
@@ -7,7 +7,7 @@
     "origin.toomanyorigins.hisskin.description": "Creeper'ın akrabası olan Hiss-kin, patlamalarını kaçış amaçlı kullanır.",
   
     "origin.toomanyorigins.swarm.name": "Swarm",
-    "origin.toomanyorigins.swarm.description": "Swarm ırkı, çatışmadan uzak duran, uzman çiftçi ve kovandan bağımsız böceklerdir.",
+    "origin.toomanyorigins.swarm.description": "Swarmlar, çatışmadan uzak duran uzman çiftçilerdir, ayrıca kovandan bağımsız yaşarlar.",
 
     "origin.toomanyorigins.undead.name": "Undead",
 


### PR DESCRIPTION
The Origin mod's turkish localization really confuses me, sometimes it uses plural you(siz), sometimes it uses singular you(sen), and either I am really dumb or it is not consistent at all, so having this in the back of my mind for more than a year now, I have come to the conclusion that Efimity had a really long talk with Apache about which origins live in groups and which don't(even though it still switches between "sen" and "siz" in the powers of the same origin). ~~thanks for coming to my ted talk~~ so ummm, which origins live in groups according to the TooManyOrigins **Lore**?

Possible explanation but still makes no sense: "siz" can also be used for singular "you" if one is talking to a higher position (eg: A pupil to a teacher can use siz while talking even tho the teacher is a single entity)

Note: Everything in TooManyOrigins' translation uses "sen" for now